### PR TITLE
amiga: restore original stack on handler exit after StackSwap

### DIFF
--- a/platform/amiga/startup.S
+++ b/platform/amiga/startup.S
@@ -38,15 +38,23 @@ _entrypoint:
 	lea	8192(a5),a0
 	move.l	a0,4(sp)		/* stk_Upper */
 	move.l	a0,8(sp)		/* stk_Pointer (top of stack) */
-	move.l	sp,a0
+	move.l	sp,a2			/* save StackSwap struct addr */
+	move.l	a2,a0
 	jsr	-0x2dc(a6)		/* StackSwap */
 
 	jsr	_handler_main		/* C entry point */
 
-	/* Swap stack back */
+	/* Swap stack back to original */
 	move.l	4.w,a6
-	/* We can't easily swap back — just exit. The handler runs
-	   until ACTION_DIE, at which point the process terminates. */
+	move.l	a2,a0			/* StackSwap struct on old stack */
+	jsr	-0x2dc(a6)		/* StackSwap — restore original stack */
+
+	/* Free the allocated stack */
+	move.l	a5,a1			/* stack memory base */
+	move.l	#8192,d0
+	jsr	-0xd2(a6)		/* FreeMem */
+
+	lea	12(sp),sp		/* remove StackSwap struct */
 	bra.s	.done
 
 .stack_ok:


### PR DESCRIPTION
## Summary
- When the handler's initial stack is < 4096 bytes, `startup.S` allocates an 8KB buffer and uses `StackSwap` to switch to it
- On exit, the original stack was never restored — `rts` on the swapped stack popped a null return address (from `MEMF_CLEAR`), causing an address error crash
- Fix: save the `StackSwap` struct address in `a2` (callee-saved), swap back on exit, free the buffer, and pop the struct before returning

## Test plan
- [x] Verified assembled code produces correct struct layout and immediates via `objdump -d`
- [x] Build succeeds with m68k-amigaos-gcc cross toolchain
- [x] Tested on Amberry: handler no longer crashes on exit