### PR TITLE
Speed up ACTION_PARENT by using parent dir entry

### DIFF
--- a/backends/iso9660/iso9660.c
+++ b/backends/iso9660/iso9660.c
@@ -326,6 +326,9 @@ static odfs_err_t iso_mount(odfs_cache_t *cache,
     }
 #endif
 
+    /* keep a verbatim copy of the root for parent resolution */
+    ctx->root = *root_out;
+
     *backend_ctx = ctx;
     return ODFS_OK;
 }
@@ -578,6 +581,199 @@ static uint32_t iso_get_volume_size(void *backend_ctx)
 }
 
 /* ------------------------------------------------------------------ */
+/* resolve_parent                                                      */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Read the ".." record at the start of a directory extent.
+ *
+ * ECMA-119 9.1 mandates that every directory begins with a "." (self) record
+ * followed by a ".." (parent) record. The ".." record carries the parent
+ * directory's extent LBA and data length, so we recover the parent's location
+ * without enumerating anything. dir_lba/parent_lba are media LBAs (session
+ * offset already applied).
+ */
+odfs_err_t odfs_iso_read_parent_extent(odfs_cache_t *cache,
+                                       uint32_t session_start,
+                                       uint32_t dir_lba,
+                                       uint32_t *parent_lba_out,
+                                       uint32_t *parent_size_out)
+{
+    const uint8_t *sector;
+    const uint8_t *self_rec;
+    const uint8_t *dotdot_rec;
+    uint8_t self_len;
+    odfs_err_t err;
+
+    err = odfs_cache_read(cache, dir_lba, &sector);
+    if (err != ODFS_OK)
+        return err;
+
+    self_rec = sector;
+    self_len = self_rec[ISO_DR_LENGTH];
+    /* "." must be a single-record self entry leaving room for ".." */
+    if (self_len < 34 || (uint32_t)self_len + 34 > ISO_SECTOR_SIZE)
+        return ODFS_ERR_BAD_FORMAT;
+
+    dotdot_rec = sector + self_len;
+    if (dotdot_rec[ISO_DR_LENGTH] < 34 ||
+        dotdot_rec[ISO_DR_NAME_LEN] != 1 ||
+        dotdot_rec[ISO_DR_NAME] != 0x01)
+        return ODFS_ERR_BAD_FORMAT;
+
+    *parent_lba_out  = iso_read_le32(&dotdot_rec[ISO_DR_EXTENT_LBA]) +
+                       session_start;
+    *parent_size_out = iso_read_le32(&dotdot_rec[ISO_DR_DATA_LENGTH]);
+    return ODFS_OK;
+}
+
+typedef struct iso_lba_match {
+    uint32_t     want_lba;
+    odfs_node_t *out;
+    int          found;
+} iso_lba_match_t;
+
+static odfs_err_t iso_lba_match_cb(const odfs_node_t *entry, void *cb_ctx)
+{
+    iso_lba_match_t *m = cb_ctx;
+
+    if (entry->kind == ODFS_NODE_DIR && entry->extent.lba == m->want_lba) {
+        *m->out = *entry;
+        m->found = 1;
+        return ODFS_ERR_EOF; /* stop iterating */
+    }
+    return ODFS_OK;
+}
+
+/*
+ * Enumerate parent_dir and return the directory child whose extent begins at
+ * child_lba as a fully-populated node (correct name + Rock Ridge metadata).
+ */
+static odfs_err_t iso_find_child_by_lba(void *backend_ctx,
+                                        odfs_cache_t *cache,
+                                        odfs_log_state_t *log,
+                                        const odfs_node_t *parent_dir,
+                                        uint32_t child_lba,
+                                        odfs_node_t *out)
+{
+    iso_lba_match_t m;
+    odfs_err_t err;
+
+    m.want_lba = child_lba;
+    m.out = out;
+    m.found = 0;
+
+    err = iso_readdir(backend_ctx, cache, log, parent_dir,
+                      iso_lba_match_cb, &m, NULL);
+    if (m.found)
+        return ODFS_OK;
+    if (err == ODFS_OK || err == ODFS_ERR_EOF)
+        return ODFS_ERR_NOT_FOUND;
+    return err;
+}
+
+/* synthesize the minimal node needed to enumerate a directory extent */
+odfs_node_t odfs_iso_dir_stub(odfs_backend_type_t backend,
+                              uint32_t lba, uint32_t size)
+{
+    odfs_node_t n;
+    memset(&n, 0, sizeof(n));
+    n.backend       = backend;
+    n.kind          = ODFS_NODE_DIR;
+    n.extent.lba    = lba;
+    n.extent.length = size;
+    n.size          = size;
+    return n;
+}
+
+static odfs_err_t iso_resolve_parent(void *backend_ctx,
+                                     odfs_cache_t *cache,
+                                     odfs_log_state_t *log,
+                                     const odfs_node_t *dir,
+                                     odfs_node_t *parent_out,
+                                     odfs_node_t *grandparent_out)
+{
+    iso_context_t *ctx = backend_ctx;
+    uint32_t ss = ctx->session_start;
+    uint32_t root_lba = ctx->pvd.root_dir_lba;
+    uint32_t parent_lba, parent_size;
+    uint32_t gp_lba, gp_size;
+    odfs_node_t grandparent;
+    odfs_err_t err;
+
+    if (dir->kind != ODFS_NODE_DIR)
+        return ODFS_ERR_NOT_DIR;
+
+    /* dir's own ".." → parent location */
+    err = odfs_iso_read_parent_extent(cache, ss, dir->extent.lba,
+                                      &parent_lba, &parent_size);
+    if (err != ODFS_OK)
+        return err;
+
+    /* a directory whose ".." points at itself is the root: no parent */
+    if (parent_lba == dir->extent.lba || dir->extent.lba == root_lba)
+        return ODFS_ERR_NOT_FOUND;
+
+    /*
+     * When the parent is the volume root, return the verbatim root node the
+     * mount built — the root has no on-disc name entry to enumerate. The
+     * grandparent of a top-level directory is also the root.
+     */
+    if (parent_lba == root_lba) {
+        *parent_out = ctx->root;
+        if (grandparent_out)
+            *grandparent_out = ctx->root;
+        return ODFS_OK;
+    }
+
+    /* parent's own ".." → grandparent location, needed to enumerate parent */
+    err = odfs_iso_read_parent_extent(cache, ss, parent_lba, &gp_lba, &gp_size);
+    if (err != ODFS_OK)
+        return err;
+
+    /* enumerate the grandparent to obtain a fully-populated parent node */
+    if (gp_lba == root_lba)
+        grandparent = ctx->root;
+    else
+        grandparent = odfs_iso_dir_stub(dir->backend, gp_lba, gp_size);
+
+    err = iso_find_child_by_lba(backend_ctx, cache, log, &grandparent,
+                                parent_lba, parent_out);
+    if (err != ODFS_OK)
+        return err;
+
+    if (!grandparent_out)
+        return ODFS_OK;
+
+    if (gp_lba == root_lba) {
+        *grandparent_out = ctx->root;
+        return ODFS_OK;
+    }
+
+    /* grandparent's ".." → great-grandparent, to populate the grandparent */
+    {
+        uint32_t ggp_lba, ggp_size;
+        odfs_node_t great;
+
+        err = odfs_iso_read_parent_extent(cache, ss, gp_lba, &ggp_lba, &ggp_size);
+        if (err != ODFS_OK)
+            return err;
+
+        if (ggp_lba == root_lba)
+            great = ctx->root;
+        else
+            great = odfs_iso_dir_stub(dir->backend, ggp_lba, ggp_size);
+
+        err = iso_find_child_by_lba(backend_ctx, cache, log, &great,
+                                    gp_lba, grandparent_out);
+        if (err != ODFS_OK)
+            return err;
+    }
+
+    return ODFS_OK;
+}
+
+/* ------------------------------------------------------------------ */
 /* backend ops table                                                   */
 /* ------------------------------------------------------------------ */
 
@@ -590,6 +786,7 @@ const odfs_backend_ops_t iso9660_backend_ops = {
     .readdir         = iso_readdir,
     .read            = iso_read,
     .lookup          = iso_lookup,
+    .resolve_parent  = iso_resolve_parent,
     .get_volume_name = iso_get_volume_name,
     .get_volume_size = iso_get_volume_size,
 };

--- a/backends/iso9660/iso9660.h
+++ b/backends/iso9660/iso9660.h
@@ -134,7 +134,26 @@ typedef struct iso_context {
     int            lowercase;     /* lowercase ISO names for display */
     int            has_rock_ridge; /* Rock Ridge extensions detected */
     int            rr_skip;       /* SP skip bytes for RR entries */
+    odfs_node_t    root;          /* verbatim root node, for parent resolution */
 } iso_context_t;
+
+/* --- shared ancestry helpers (used by iso9660 and joliet) --- */
+
+/*
+ * Read the parent directory's extent location from the ".." record at the
+ * start of the directory extent at dir_lba (a media LBA). On success returns
+ * the parent's media LBA and on-disc data length. Both ISO9660 and Joliet
+ * share the ECMA-119 directory-record layout, so this works for either.
+ */
+odfs_err_t odfs_iso_read_parent_extent(odfs_cache_t *cache,
+                                       uint32_t session_start,
+                                       uint32_t dir_lba,
+                                       uint32_t *parent_lba_out,
+                                       uint32_t *parent_size_out);
+
+/* synthesize the minimal directory node needed to enumerate an extent */
+odfs_node_t odfs_iso_dir_stub(odfs_backend_type_t backend,
+                              uint32_t lba, uint32_t size);
 
 /* --- backend ops (exposed for registration) --- */
 

--- a/backends/joliet/joliet.c
+++ b/backends/joliet/joliet.c
@@ -245,6 +245,9 @@ static odfs_err_t joliet_mount(odfs_cache_t *cache,
     joliet_parse_dir_date(&ctx->svd.root_dir_record[ISO_DR_DATE], &root_out->mtime);
     root_out->ctime = root_out->mtime;
 
+    /* keep a verbatim copy of the root for parent resolution */
+    ctx->root = *root_out;
+
     *backend_ctx = ctx;
     return ODFS_OK;
 }
@@ -458,6 +461,130 @@ static uint32_t joliet_get_volume_size(void *backend_ctx)
 }
 
 /* ------------------------------------------------------------------ */
+/* resolve_parent                                                      */
+/* ------------------------------------------------------------------ */
+
+typedef struct joliet_lba_match {
+    uint32_t     want_lba;
+    odfs_node_t *out;
+    int          found;
+} joliet_lba_match_t;
+
+static odfs_err_t joliet_lba_match_cb(const odfs_node_t *entry, void *cb_ctx)
+{
+    joliet_lba_match_t *m = cb_ctx;
+
+    if (entry->kind == ODFS_NODE_DIR && entry->extent.lba == m->want_lba) {
+        *m->out = *entry;
+        m->found = 1;
+        return ODFS_ERR_EOF;
+    }
+    return ODFS_OK;
+}
+
+/* enumerate parent_dir; return the dir child whose extent begins at child_lba */
+static odfs_err_t joliet_find_child_by_lba(void *backend_ctx,
+                                           odfs_cache_t *cache,
+                                           odfs_log_state_t *log,
+                                           const odfs_node_t *parent_dir,
+                                           uint32_t child_lba,
+                                           odfs_node_t *out)
+{
+    joliet_lba_match_t m;
+    odfs_err_t err;
+
+    m.want_lba = child_lba;
+    m.out = out;
+    m.found = 0;
+
+    err = joliet_readdir(backend_ctx, cache, log, parent_dir,
+                         joliet_lba_match_cb, &m, NULL);
+    if (m.found)
+        return ODFS_OK;
+    if (err == ODFS_OK || err == ODFS_ERR_EOF)
+        return ODFS_ERR_NOT_FOUND;
+    return err;
+}
+
+static odfs_err_t joliet_resolve_parent(void *backend_ctx,
+                                        odfs_cache_t *cache,
+                                        odfs_log_state_t *log,
+                                        const odfs_node_t *dir,
+                                        odfs_node_t *parent_out,
+                                        odfs_node_t *grandparent_out)
+{
+    joliet_context_t *ctx = backend_ctx;
+    uint32_t ss = ctx->session_start;
+    uint32_t root_lba = ctx->svd.root_dir_lba;
+    uint32_t parent_lba, parent_size;
+    uint32_t gp_lba, gp_size;
+    odfs_node_t grandparent;
+    odfs_err_t err;
+
+    if (dir->kind != ODFS_NODE_DIR)
+        return ODFS_ERR_NOT_DIR;
+
+    err = odfs_iso_read_parent_extent(cache, ss, dir->extent.lba,
+                                      &parent_lba, &parent_size);
+    if (err != ODFS_OK)
+        return err;
+
+    if (parent_lba == dir->extent.lba || dir->extent.lba == root_lba)
+        return ODFS_ERR_NOT_FOUND;
+
+    if (parent_lba == root_lba) {
+        *parent_out = ctx->root;
+        if (grandparent_out)
+            *grandparent_out = ctx->root;
+        return ODFS_OK;
+    }
+
+    err = odfs_iso_read_parent_extent(cache, ss, parent_lba, &gp_lba, &gp_size);
+    if (err != ODFS_OK)
+        return err;
+
+    if (gp_lba == root_lba)
+        grandparent = ctx->root;
+    else
+        grandparent = odfs_iso_dir_stub(dir->backend, gp_lba, gp_size);
+
+    err = joliet_find_child_by_lba(backend_ctx, cache, log, &grandparent,
+                                   parent_lba, parent_out);
+    if (err != ODFS_OK)
+        return err;
+
+    if (!grandparent_out)
+        return ODFS_OK;
+
+    if (gp_lba == root_lba) {
+        *grandparent_out = ctx->root;
+        return ODFS_OK;
+    }
+
+    {
+        uint32_t ggp_lba, ggp_size;
+        odfs_node_t great;
+
+        err = odfs_iso_read_parent_extent(cache, ss, gp_lba,
+                                          &ggp_lba, &ggp_size);
+        if (err != ODFS_OK)
+            return err;
+
+        if (ggp_lba == root_lba)
+            great = ctx->root;
+        else
+            great = odfs_iso_dir_stub(dir->backend, ggp_lba, ggp_size);
+
+        err = joliet_find_child_by_lba(backend_ctx, cache, log, &great,
+                                       gp_lba, grandparent_out);
+        if (err != ODFS_OK)
+            return err;
+    }
+
+    return ODFS_OK;
+}
+
+/* ------------------------------------------------------------------ */
 /* backend ops table                                                   */
 /* ------------------------------------------------------------------ */
 
@@ -470,6 +597,7 @@ const odfs_backend_ops_t joliet_backend_ops = {
     .readdir         = joliet_readdir,
     .read            = joliet_read,
     .lookup          = joliet_lookup,
+    .resolve_parent  = joliet_resolve_parent,
     .get_volume_name = joliet_get_volume_name,
     .get_volume_size = joliet_get_volume_size,
 };

--- a/backends/joliet/joliet.h
+++ b/backends/joliet/joliet.h
@@ -20,6 +20,7 @@ typedef struct joliet_context {
     iso_pvd_info_t svd;            /* parsed from SVD (same structure as PVD) */
     uint32_t       session_start;
     uint32_t       next_node_id;
+    odfs_node_t    root;           /* verbatim root node, for parent resolution */
 } joliet_context_t;
 
 extern const odfs_backend_ops_t joliet_backend_ops;

--- a/core/ancestry.c
+++ b/core/ancestry.c
@@ -23,14 +23,6 @@ typedef struct ancestry_search_ctx {
     int                descend;
 } ancestry_search_ctx_t;
 
-static int ancestry_is_root(const odfs_mount_t *mnt, const odfs_node_t *node)
-{
-    if (!mnt || !node)
-        return 0;
-
-    return odfs_node_matches_identity(node, &mnt->root);
-}
-
 static odfs_err_t ancestry_search_cb(const odfs_node_t *entry, void *ctx)
 {
     ancestry_search_ctx_t *asc = ctx;
@@ -50,21 +42,20 @@ static odfs_err_t ancestry_search_cb(const odfs_node_t *entry, void *ctx)
     return ODFS_OK;
 }
 
-odfs_err_t odfs_resolve_parent_node(odfs_mount_t *mnt,
-                                    const odfs_node_t *node,
-                                    odfs_node_t *parent_out,
-                                    odfs_node_t *grandparent_out)
+/*
+ * Generic fallback: locate a node's parent by depth-first search of the
+ * mounted tree. O(directories on the volume); used only when the backend
+ * has no resolve_parent op (or it declined the request).
+ */
+odfs_err_t odfs_resolve_parent_search(odfs_mount_t *mnt,
+                                      const odfs_node_t *node,
+                                      odfs_node_t *parent_out,
+                                      odfs_node_t *grandparent_out)
 {
     ancestry_frame_t *frames;
     size_t cap = 8;
     size_t depth = 1;
     odfs_err_t err = ODFS_ERR_NOT_FOUND;
-
-    if (!mnt || !node || !parent_out)
-        return ODFS_ERR_INVAL;
-
-    if (ancestry_is_root(mnt, node))
-        return ODFS_ERR_NOT_FOUND;
 
     frames = odfs_malloc(cap * sizeof(*frames));
     if (!frames)

--- a/core/mount.c
+++ b/core/mount.c
@@ -5,6 +5,7 @@
  */
 
 #include "odfs/api.h"
+#include "odfs/ancestry.h"
 #include "odfs/string.h"
 #include <string.h>
 #include <inttypes.h>
@@ -534,6 +535,34 @@ odfs_err_t odfs_lookup(odfs_mount_t *mnt,
         return ODFS_ERR_UNSUPPORTED;
 
     return ops->lookup(backend_ctx, &mnt->cache, &mnt->log, dir, name, out);
+}
+
+odfs_err_t odfs_resolve_parent_node(odfs_mount_t *mnt,
+                                    const odfs_node_t *node,
+                                    odfs_node_t *parent_out,
+                                    odfs_node_t *grandparent_out)
+{
+    const odfs_backend_ops_t *ops;
+    void *backend_ctx;
+
+    if (!mnt || !node || !parent_out)
+        return ODFS_ERR_INVAL;
+
+    if (mount_is_root(mnt, node))
+        return ODFS_ERR_NOT_FOUND;
+
+    /* prefer the backend's direct resolver, if it has one */
+    if (mount_backend_for_type(mnt, node->backend, &ops, &backend_ctx) &&
+        ops && ops->resolve_parent) {
+        odfs_err_t err = ops->resolve_parent(backend_ctx, &mnt->cache,
+                                             &mnt->log, node,
+                                             parent_out, grandparent_out);
+        /* UNSUPPORTED means "use the generic search for this node" */
+        if (err != ODFS_ERR_UNSUPPORTED)
+            return err;
+    }
+
+    return odfs_resolve_parent_search(mnt, node, parent_out, grandparent_out);
 }
 
 odfs_err_t odfs_resolve_path(odfs_mount_t *mnt,

--- a/include/odfs/ancestry.h
+++ b/include/odfs/ancestry.h
@@ -24,4 +24,15 @@ odfs_err_t odfs_resolve_parent_node(odfs_mount_t *mnt,
                                     odfs_node_t *parent_out,
                                     odfs_node_t *grandparent_out);
 
+/*
+ * Generic fallback used when the active backend exposes no resolve_parent op
+ * (or it declines a particular node). Locates the parent by depth-first
+ * search of the mounted tree. Not for direct use — call
+ * odfs_resolve_parent_node, which dispatches to the backend first.
+ */
+odfs_err_t odfs_resolve_parent_search(odfs_mount_t *mnt,
+                                      const odfs_node_t *node,
+                                      odfs_node_t *parent_out,
+                                      odfs_node_t *grandparent_out);
+
 #endif /* ODFS_ANCESTRY_H */

--- a/include/odfs/backend.h
+++ b/include/odfs/backend.h
@@ -87,6 +87,26 @@ typedef struct odfs_backend_ops {
                           odfs_node_t *out);
 
     /*
+     * Resolve the parent (and optional grandparent) of a directory node
+     * directly, without a tree walk. May be NULL, in which case the core
+     * falls back to a generic search.
+     *
+     *   dir             — the directory whose parent is wanted
+     *   parent_out      — receives the containing directory
+     *   grandparent_out — if non-NULL, receives the parent's parent (or the
+     *                     volume root when parent_out is the root)
+     *
+     * Returns ODFS_ERR_NOT_FOUND when dir is the root (has no parent), or
+     * ODFS_ERR_UNSUPPORTED to ask the core to use the generic search.
+     */
+    odfs_err_t (*resolve_parent)(void *backend_ctx,
+                                  odfs_cache_t *cache,
+                                  odfs_log_state_t *log,
+                                  const odfs_node_t *dir,
+                                  odfs_node_t *parent_out,
+                                  odfs_node_t *grandparent_out);
+
+    /*
      * Get volume name. May be NULL if not applicable.
      *   buf      — output buffer
      *   buf_size — size of output buffer

--- a/tests/unit/test_resolve_parent.c
+++ b/tests/unit/test_resolve_parent.c
@@ -1,0 +1,171 @@
+/*
+ * test_resolve_parent.c — backend resolve_parent fast-path coverage
+ *
+ * Mounts real ISO9660 / Joliet fixtures and verifies that
+ * odfs_resolve_parent_node (which dispatches to the backend's ".."-based
+ * resolver) returns the correct parent and grandparent, and that its result
+ * is identical to the generic tree search fallback.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "odfs/api.h"
+#include "odfs/ancestry.h"
+#include "odfs/error.h"
+#include "test_harness.h"
+
+#include <string.h>
+
+/* the plain ISO fixture contains /DEEP/SUBDIR/NESTED.TXT */
+#define IMG_PLAIN  "tests/images/test_plain.iso"
+#define IMG_JOLIET "tests/images/test_joliet.iso"
+
+static int mount_image(const char *path, int prefer_joliet,
+                       odfs_media_t *media, odfs_log_state_t *log,
+                       odfs_mount_t *mnt)
+{
+    odfs_mount_opts_t opts;
+
+    if (odfs_media_open_image(path, media) != ODFS_OK)
+        return 0;
+
+    odfs_log_init(log);
+    odfs_mount_opts_default(&opts);
+    if (prefer_joliet)
+        opts.disable_joliet = 0;
+
+    if (odfs_mount(media, &opts, log, mnt) != ODFS_OK) {
+        odfs_media_close(media);
+        return 0;
+    }
+    return 1;
+}
+
+/*
+ * Resolve via the backend fast path, then via the generic search, and assert
+ * the two agree on identity (extent + name). Writes the fast-path parent and
+ * grandparent into (parent_out, grandparent_out) for further inspection.
+ *
+ * A macro rather than a function so the ASSERT_* checks abort the enclosing
+ * TEST (they reference the TEST-local _fail_count).
+ */
+#define ASSERT_PARENT_MATCHES_SEARCH(mnt, node, parent_out, grandparent_out) \
+    do { \
+        odfs_node_t _sp, _sgp; \
+        ASSERT_OK(odfs_resolve_parent_node((mnt), (node), \
+                                           (parent_out), (grandparent_out))); \
+        ASSERT_OK(odfs_resolve_parent_search((mnt), (node), &_sp, &_sgp)); \
+        ASSERT(odfs_node_matches_identity((parent_out), &_sp)); \
+        ASSERT(odfs_node_matches_identity((grandparent_out), &_sgp)); \
+    } while (0)
+
+TEST(resolve_parent_iso_two_levels_deep)
+{
+    odfs_media_t media;
+    odfs_log_state_t log;
+    odfs_mount_t mnt;
+    odfs_node_t subdir, parent, grandparent;
+
+    if (!mount_image(IMG_PLAIN, 0, &media, &log, &mnt)) {
+        printf("  (skipped: %s)\n", "fixture " IMG_PLAIN " unavailable");
+        return;
+    }
+
+    /* /DEEP/SUBDIR -> parent DEEP, grandparent root */
+    ASSERT_OK(odfs_resolve_path(&mnt, "/DEEP/SUBDIR", &subdir));
+    ASSERT_PARENT_MATCHES_SEARCH(&mnt, &subdir, &parent, &grandparent);
+    ASSERT_STR_EQ(parent.name, "DEEP");
+    ASSERT(odfs_node_matches_identity(&grandparent, &mnt.root));
+
+    odfs_unmount(&mnt);
+}
+
+TEST(resolve_parent_iso_top_level)
+{
+    odfs_media_t media;
+    odfs_log_state_t log;
+    odfs_mount_t mnt;
+    odfs_node_t deep, parent, grandparent;
+
+    if (!mount_image(IMG_PLAIN, 0, &media, &log, &mnt)) {
+        printf("  (skipped: %s)\n", "fixture " IMG_PLAIN " unavailable");
+        return;
+    }
+
+    /* /DEEP -> parent root, grandparent root */
+    ASSERT_OK(odfs_resolve_path(&mnt, "/DEEP", &deep));
+    ASSERT_PARENT_MATCHES_SEARCH(&mnt, &deep, &parent, &grandparent);
+    ASSERT(odfs_node_matches_identity(&parent, &mnt.root));
+    ASSERT(odfs_node_matches_identity(&grandparent, &mnt.root));
+
+    odfs_unmount(&mnt);
+}
+
+TEST(resolve_parent_root_has_no_parent)
+{
+    odfs_media_t media;
+    odfs_log_state_t log;
+    odfs_mount_t mnt;
+    odfs_node_t parent;
+
+    if (!mount_image(IMG_PLAIN, 0, &media, &log, &mnt)) {
+        printf("  (skipped: %s)\n", "fixture " IMG_PLAIN " unavailable");
+        return;
+    }
+
+    ASSERT_ERR(odfs_resolve_parent_node(&mnt, &mnt.root, &parent, NULL),
+               ODFS_ERR_NOT_FOUND);
+
+    odfs_unmount(&mnt);
+}
+
+TEST(resolve_parent_without_grandparent_out)
+{
+    odfs_media_t media;
+    odfs_log_state_t log;
+    odfs_mount_t mnt;
+    odfs_node_t subdir, parent;
+
+    if (!mount_image(IMG_PLAIN, 0, &media, &log, &mnt)) {
+        printf("  (skipped: %s)\n", "fixture " IMG_PLAIN " unavailable");
+        return;
+    }
+
+    /* grandparent_out == NULL must be accepted */
+    ASSERT_OK(odfs_resolve_path(&mnt, "/DEEP/SUBDIR", &subdir));
+    ASSERT_OK(odfs_resolve_parent_node(&mnt, &subdir, &parent, NULL));
+    ASSERT_STR_EQ(parent.name, "DEEP");
+
+    odfs_unmount(&mnt);
+}
+
+TEST(resolve_parent_joliet)
+{
+    odfs_media_t media;
+    odfs_log_state_t log;
+    odfs_mount_t mnt;
+    odfs_node_t dir, parent, grandparent;
+
+    if (!mount_image(IMG_JOLIET, 1, &media, &log, &mnt)) {
+        printf("  (skipped: %s)\n", "fixture " IMG_JOLIET " unavailable");
+        return;
+    }
+
+    /* the Joliet fixture mirrors the plain ISO: /DEEP/SUBDIR */
+    if (odfs_resolve_path(&mnt, "/DEEP/SUBDIR", &dir) == ODFS_OK) {
+        odfs_node_t level1;
+
+        ASSERT_PARENT_MATCHES_SEARCH(&mnt, &dir, &parent, &grandparent);
+        ASSERT(odfs_node_matches_identity(&grandparent, &mnt.root));
+
+        /* and the parent (DEEP) resolves up to the root */
+        ASSERT_PARENT_MATCHES_SEARCH(&mnt, &parent, &level1, &grandparent);
+        ASSERT(odfs_node_matches_identity(&level1, &mnt.root));
+    } else {
+        printf("  (skipped: %s)\n", "Joliet fixture lacks /DEEP/SUBDIR");
+    }
+
+    odfs_unmount(&mnt);
+}
+
+TEST_MAIN()


### PR DESCRIPTION
For iso9660, joliet, rock ridge etc, use the '..' directory entry to find the parent instead of scanning the entire directory tree to find it

This greatly improves performance especially on m68k, even on WinUAE with 68030 + fastest possible it brings the boot time from over 7 seconds down to 2, it might be worse for real machines given seek times etc