### PR TITLE
Raise the minimum handler stack to 16K

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ If you want a plain Mountlist entry instead, add one such as:
 ```text
 CD0:
     Handler   = L:ODFileSystem
-    Stacksize = 8192
+    Stacksize = 16384
     Priority  = 5
     GlobVec   = -1
     DosType   = 0x43443031

--- a/docs/mountlist.example
+++ b/docs/mountlist.example
@@ -14,7 +14,7 @@
 
 CD0:
     Handler   = L:ODFileSystem
-    Stacksize = 8192
+    Stacksize = 16384
     Priority  = 5
     GlobVec   = -1
     DosType   = 0x43443031

--- a/platform/amiga/startup.S
+++ b/platform/amiga/startup.S
@@ -36,8 +36,13 @@
 #define MEMF_PUBLIC	0x00000001
 #define MEMF_CLEAR	0x00010000
 
-#define MIN_STACK	4096
-#define SWAP_STACK	8192
+/*
+ * The handler's deep paths (directory traversal, name normalization) can use
+ * more stack than a mountlist typically grants. Guarantee a minimum by swapping
+ * to a private stack of this size when the supplied one is smaller.
+ */
+#define MIN_STACK	16384
+#define SWAP_STACK	16384
 
 _start:
 _entrypoint:


### PR DESCRIPTION
The handler's deep paths (directory traversal, name normalization) can use more stack than a mountlist typically grants.

I got a MuGA low stack hit with 8KB of stack, and the -test version needs some more for RawDoFmt. Technically we could get away with 10-12KB of stack, but let's go safe with 16KB, matching the ROM filesystem.
