### PR TITLE
Fix builds with multisession support disabled

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Build and run host unit tests
         run: make check
 
+      - name: Build host library without multisession support
+        run: >-
+          make lib HOST_BUILD=build/host-no-multisession
+          CPPFLAGS=-DODFS_FEATURE_MULTISESSION=0
+
       - name: Run golden image tests
         run: make golden-check
 

--- a/core/mount.c
+++ b/core/mount.c
@@ -58,7 +58,9 @@ static size_t mount_build_session_candidates(odfs_mount_t *mnt,
                                              uint32_t *starts,
                                              size_t max_starts)
 {
+#if ODFS_FEATURE_MULTISESSION
     odfs_toc_t toc;
+#endif
     size_t count = 0;
 
     if (!mnt || !starts || max_starts == 0)


### PR DESCRIPTION
Building with `ODFS_FEATURE_MULTISESSION=0` fails under `-Werror` because `mount_build_session_candidates()` still declares `toc` while all of its uses are compiled out. Guard the declaration with the same feature flag.

Add a CI build of the host library with multisession disabled in a separate output directory to catch this configuration regression without reusing default-build objects.

Validation:
- Reproduced the unused-variable error on the upstream source.
- Fresh host library build with `ODFS_FEATURE_MULTISESSION=0` passed.
- Fresh OS3 handler build with `FEATURE_MULTISESSION=0` passed.
- All 112 default host unit tests passed.
